### PR TITLE
Add redirects for ccs-forms domain

### DIFF
--- a/files/httpd.conf
+++ b/files/httpd.conf
@@ -372,6 +372,7 @@ php_value expose_php "off"
     # Pages
     RedirectMatch 301 ^/suppliers(/.*)?$            https://www.crowncommercial.gov.uk/suppliers
     RedirectMatch 301 ^/contact(/.*)?$              https://www.crowncommercial.gov.uk/contact
+    RedirectMatch 301 ^/contact-us(/.*)?$              https://www.crowncommercial.gov.uk/contact
     RedirectMatch 301 ^/i-am-buyer(/.*)?$           https://www.crowncommercial.gov.uk/help-and-support/
     RedirectMatch 301 ^/procurement-pipeline(/.*)?$ https://www.crowncommercial.gov.uk/agreements/upcoming
     RedirectMatch 301 ^/office$	                    https://www.crowncommercial.gov.uk/agreements/pillar/people

--- a/files/httpd.conf
+++ b/files/httpd.conf
@@ -365,6 +365,8 @@ php_value expose_php "off"
 
     # Framework detail page
     RedirectMatch 301 ^/contracts/(.*)$             https://www.crowncommercial.gov.uk/agreements/$1
+    RedirectMatch 301 ^/i-am-buyer/find-a-product-or-service	https://www.crowncommercial.gov.uk/agreements/$1
+    RedirectMatch 301 ^/category-information-and-updates 	https://www.crowncommercial.gov.uk/agreements/$1
 
     # Suppliers detail pages (to search)
     RedirectMatch 301 ^/suppliers/(.*)$             https://www.crowncommercial.gov.uk/suppliers/search?q=$1&t=old
@@ -380,6 +382,7 @@ php_value expose_php "off"
     RedirectMatch 301 ^/legal-notice/bribery-act$	https://www.crowncommercial.gov.uk/terms-and-conditions/
     RedirectMatch 301 ^/re-use-notices/reuse-faq$	https://www.crowncommercial.gov.uk/terms-and-conditions/
     RedirectMatch 301 ^/using-esourcing-suite-0$	https://www.crowncommercial.gov.uk/esourcing-register
+    RedirectMatch 301 ^/booking$        https://www.crowncommercial.gov.uk/esourcing-register
     RedirectMatch 301 ^/data-and-application-solutions$	            https://www.crowncommercial.gov.uk/agreements/RM3821
     RedirectMatch 301 ^/category-information-and-updates/travel$	https://www.crowncommercial.gov.uk/agreements/category/travel
     RedirectMatch 301 ^/category-information-and-updates/technology$	https://www.crowncommercial.gov.uk/agreements/category/technology-products-services
@@ -394,6 +397,7 @@ php_value expose_php "off"
     RedirectMatch 301 ^/category-information-and-updates/energy/energy-growth$	https://www.crowncommercial.gov.uk/agreements/category/utilities-fuels
     RedirectMatch 301 ^/category-information-and-updates/energy/liquefied-petroleum-gas-lpg$	https://www.crowncommercial.gov.uk/agreements/category/utilities-fuels
     RedirectMatch 301 ^/category-information-and-updates/facilities-management-property/nec3-term-service-contract$	 https://www.crowncommercial.gov.uk/agreements/category/workplace
+    RedirectMatch 301 ^/category-information-and-updates/office$      https://www.crowncommercial.gov.uk/agreements/category/document-management-logistics
     RedirectMatch 301 ^/insurance-services-non-disclosure-agreement$        https://www.crowncommercial.gov.uk/insurance-services-nda
     
     # Old Drupal URLs

--- a/files/httpd.conf
+++ b/files/httpd.conf
@@ -341,9 +341,10 @@ php_value expose_php "off"
 
 </VirtualHost>
 
-# Redirects: ccs-agreements.cabinetoffice.gov.uk
+# Redirects: ccs-agreements.cabinetoffice.gov.uk and ccs-forms.cabinetoffice.gov.uk
 <VirtualHost *:80>
     ServerName ccs-agreements.cabinetoffice.gov.uk
+    ServerAlias ccs-forms.cabinetoffice.gov.uk
 
     DocumentRoot /var/www/html
 


### PR DESCRIPTION
Adding redirects for ccs-forms.cabinetoffice.gov.uk so that the domain can be forwarded directly to Production